### PR TITLE
Fix ElementFormControlDataSelect not showing selection

### DIFF
--- a/Source/Core/Elements/ElementFormControlDataSelect.cpp
+++ b/Source/Core/Elements/ElementFormControlDataSelect.cpp
@@ -69,6 +69,8 @@ void ElementFormControlDataSelect::OnUpdate()
 			BuildOptions();
 		}
 	}
+
+	ElementFormControlSelect::OnUpdate();
 }
 
 // Checks for changes to the data source or formatting attributes.


### PR DESCRIPTION
WidgetDropDown::OnUpdate which is needed to show the current selection was never called.