### PR TITLE
Explicitly include cstdint to fix compile errors

### DIFF
--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -31,6 +31,7 @@
 
 #include "../Config/Config.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 


### PR DESCRIPTION
```
[  0%] Building CXX object CMakeFiles/RMLUI_LIB.dir/libs/RmlUi/Source/Core/Element.cpp.o In file included from /mnt/media/code/Unvanquished/libs/RmlUi/Source/Core/Element.cpp:52: /mnt/media/code/Unvanquished/libs/RmlUi/Source/Core/ElementStyle.h:43:6: warning: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword
   43 | enum class PseudoClassState : std::uint8_t { Clear = 0, Set = 1, Override = 2 };
      | ~~~~ ^~~~~
      |      -----
```