### PR TITLE
RMLUI_LUA_AS_CXX macro from upstream

### DIFF
--- a/Include/RmlUi/Lua/IncludeLua.h
+++ b/Include/RmlUi/Lua/IncludeLua.h
@@ -4,7 +4,7 @@
  * For the latest information, see http://github.com/mikke89/RmlUi
  *
  * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
- * Copyright (c) 2019 The RmlUi Team, and contributors
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -15,7 +15,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,15 +25,21 @@
  * THE SOFTWARE.
  *
  */
- 
-#ifndef RMLUI_LUA_INCLUDELUA_H
-#define RMLUI_LUA_INCLUDELUA_H 
 
-//The standard Lua headers
+#ifndef RMLUI_LUA_INCLUDELUA_H
+#define RMLUI_LUA_INCLUDELUA_H
+
+#ifndef RMLUI_LUA_AS_CXX
 extern "C" {
-#include <lua.h>
+#endif
+
+// The standard Lua headers
 #include <lauxlib.h>
+#include <lua.h>
 #include <lualib.h>
+
+#ifndef RMLUI_LUA_AS_CXX
 }
+#endif
 
 #endif


### PR DESCRIPTION
So we have the option to build against the Lua library built as C++. See https://github.com/Unvanquished/Unvanquished/issues/3035