### PR TITLE
Make the source unity build-friendly

### DIFF
--- a/Include/RmlUi/Core/StyleSheetSpecification.h
+++ b/Include/RmlUi/Core/StyleSheetSpecification.h
@@ -133,6 +133,8 @@ private:
 	PropertySpecification properties;
 
 	UniquePtr<DefaultStyleSheetParsers> default_parsers;
+
+	static StyleSheetSpecification* instance; // singleton
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -37,8 +37,8 @@
 
 namespace Rml {
 
-static const float DEFAULT_REPEAT_DELAY = 0.5f;
-static const float DEFAULT_REPEAT_PERIOD = 0.1f;
+static const float SLIDER_ARROW_REPEAT_DELAY = 0.5f;
+static const float SLIDER_ARROW_REPEAT_PERIOD = 0.1f;
 
 WidgetSlider::WidgetSlider(ElementFormControl* _parent)
 {
@@ -156,7 +156,7 @@ void WidgetSlider::Update()
 			arrow_timers[i] -= delta_time;
 			while (arrow_timers[i] <= 0)
 			{
-				arrow_timers[i] += DEFAULT_REPEAT_PERIOD;
+				arrow_timers[i] += SLIDER_ARROW_REPEAT_PERIOD;
 				SetBarPosition(i == 0 ? OnLineDecrement() : OnLineIncrement());
 			}
 		}
@@ -390,13 +390,13 @@ void WidgetSlider::ProcessEvent(Event& event)
 		}
 		else if (event.GetTargetElement() == arrows[0])
 		{
-			arrow_timers[0] = DEFAULT_REPEAT_DELAY;
+			arrow_timers[0] = SLIDER_ARROW_REPEAT_DELAY;
 			last_update_time = Clock::GetElapsedTime();
 			SetBarPosition(OnLineDecrement());
 		}
 		else if (event.GetTargetElement() == arrows[1])
 		{
-			arrow_timers[1] = DEFAULT_REPEAT_DELAY;
+			arrow_timers[1] = SLIDER_ARROW_REPEAT_DELAY;
 			last_update_time = Clock::GetElapsedTime();
 			SetBarPosition(OnLineIncrement());
 		}

--- a/Source/Core/StyleSheetFactory.cpp
+++ b/Source/Core/StyleSheetFactory.cpp
@@ -36,7 +36,7 @@
 
 namespace Rml {
 
-static UniquePtr<StyleSheetFactory> instance;
+UniquePtr<StyleSheetFactory> StyleSheetFactory::instance;
 
 StyleSheetFactory::StyleSheetFactory() :
 	selectors{

--- a/Source/Core/StyleSheetFactory.h
+++ b/Source/Core/StyleSheetFactory.h
@@ -78,6 +78,8 @@ private:
 	// Custom complex selectors available for style sheets.
 	using SelectorMap = UnorderedMap<String, StructuralSelectorType>;
 	SelectorMap selectors;
+
+	static UniquePtr<StyleSheetFactory> instance; // singleton
 };
 
 } // namespace Rml

--- a/Source/Core/StyleSheetNode.cpp
+++ b/Source/Core/StyleSheetNode.cpp
@@ -37,11 +37,6 @@
 
 namespace Rml {
 
-static inline bool IsTextElement(const Element* element)
-{
-	return element->GetTagName() == "#text";
-}
-
 StyleSheetNode::StyleSheetNode()
 {
 	CalculateAndSetSpecificity();
@@ -329,7 +324,7 @@ bool StyleSheetNode::TraverseMatch(const Element* element) const
 		{
 			// First check if our sibling is a text element and if so skip it. For the descendant/child combinator above we can omit this step since
 			// text elements don't have children and thus any ancestor is not a text element.
-			if (IsTextElement(element))
+			if (element->GetTagName() == "#text")
 				continue;
 			else if (parent->Match(element) && parent->TraverseMatch(element))
 				return true;

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -43,7 +43,7 @@
 
 namespace Rml {
 
-static StyleSheetSpecification* instance = nullptr;
+StyleSheetSpecification* StyleSheetSpecification::instance = nullptr;
 
 
 struct DefaultStyleSheetParsers {

--- a/Source/Core/WidgetScroll.cpp
+++ b/Source/Core/WidgetScroll.cpp
@@ -37,8 +37,8 @@
 
 namespace Rml {
 
-static const float DEFAULT_REPEAT_DELAY = 0.5f;
-static const float DEFAULT_REPEAT_PERIOD = 0.1f;
+static const float SCROLL_ARROW_REPEAT_DELAY = 0.5f;
+static const float SCROLL_ARROW_REPEAT_PERIOD = 0.1f;
 
 WidgetScroll::WidgetScroll(Element* _parent)
 {
@@ -160,7 +160,7 @@ void WidgetScroll::Update()
 			arrow_timers[i] -= delta_time;
 			while (arrow_timers[i] <= 0)
 			{
-				arrow_timers[i] += DEFAULT_REPEAT_PERIOD;
+				arrow_timers[i] += SCROLL_ARROW_REPEAT_PERIOD;
 				SetBarPosition(i == 0 ? OnLineDecrement() : OnLineIncrement());
 			}
 		}
@@ -432,13 +432,13 @@ void WidgetScroll::ProcessEvent(Event& event)
 	{
 		if (event.GetTargetElement() == arrows[0])
 		{
-			arrow_timers[0] = DEFAULT_REPEAT_DELAY;
+			arrow_timers[0] = SCROLL_ARROW_REPEAT_DELAY;
 			last_update_time = Clock::GetElapsedTime();
 			SetBarPosition(OnLineDecrement());
 		}
 		else if (event.GetTargetElement() == arrows[1])
 		{
-			arrow_timers[1] = DEFAULT_REPEAT_DELAY;
+			arrow_timers[1] = SCROLL_ARROW_REPEAT_DELAY;
 			last_update_time = Clock::GetElapsedTime();
 			SetBarPosition(OnLineIncrement());
 		}

--- a/Source/Debugger/CommonSource.h
+++ b/Source/Debugger/CommonSource.h
@@ -26,6 +26,9 @@
  *
  */
 
+#ifndef RMLUI_DEBUGGER_COMMONSOURCE_H
+#define RMLUI_DEBUGGER_COMMONSOURCE_H
+
 static const char* common_rcss = R"RCSS(
 body
 {
@@ -195,3 +198,5 @@ handle#size_handle
 	background-color: #888;
 }
 )RCSS";
+
+#endif


### PR DESCRIPTION
Avoid name collisions of static globals and add a missing header guard.

This is enough to build all sources used by Unvanquished concatenated, except SystemInterface.cpp