### PR TITLE
Fix robin_hood.h compilation errors with GCC 15

### DIFF
--- a/Include/RmlUi/Core/Containers/robin_hood.h
+++ b/Include/RmlUi/Core/Containers/robin_hood.h
@@ -40,6 +40,7 @@
 
 #include <limits>
 #include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
This is a change cherry-picked from upstream and approved by me, so I will merge after 24h.